### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Docker Image CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/codingdud/mongodb-cluster-monitor/security/code-scanning/2](https://github.com/codingdud/mongodb-cluster-monitor/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions:` block for the workflow or specific job and grant only the minimal GitHub token scopes required. For this workflow, the visible steps only need read access to the repository contents (for checkout). Docker Hub authentication uses secrets, not `GITHUB_TOKEN`, so it does not affect required permissions.

The simplest, least intrusive fix is to add a workflow-level `permissions:` section right after the `name:` (or after `on:`) setting `contents: read`. This applies to all jobs unless they override it, and it documents that the workflow only needs read access to repo contents. No other scopes (issues, pull-requests, packages, etc.) are evidently required by the shown steps. Concretely, in `.github/workflows/docker-image.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` (or equivalently between `on:` and `jobs:`); this does not change logic and just constrains `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
