### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "mongodb": "^6.3.0",
-    "nodemailer": "^8.0.2"
+    "nodemailer": "^8.0.2",
+    "express-rate-limit": "^8.3.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -3,10 +3,16 @@ const express = require('express');
 const path    = require('path');
 const logger  = require('./lib/logger');
 const MonitorEngine = require('./lib/engine');
+const rateLimit = require('express-rate-limit');
 
 const PORT = parseInt(process.env.PORT || '4000', 10);
 const app    = express();
 const engine = new MonitorEngine();
+
+const frontendLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
@@ -125,7 +131,7 @@ app.get('/api/events', (req, res) => {
 });
 
 // ── Serve frontend ─────────────────────────────────────────────────────────
-app.get('*', (req, res) => {
+app.get('*', frontendLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/codingdud/mongodb-cluster-monitor/security/code-scanning/1](https://github.com/codingdud/mongodb-cluster-monitor/security/code-scanning/1)

In general, to fix missing rate limiting on a filesystem-accessing route in Express, introduce a rate-limiting middleware (for example, via the `express-rate-limit` package) and apply it to the specific route or group of routes that perform expensive operations. This ensures that a single client (as identified by IP or another key) cannot make unbounded numbers of requests in a short time, reducing DoS risk without changing the route’s core behavior.

For this code, the least intrusive fix is: (1) require `express-rate-limit` near the top of `server.js`, (2) configure a reasonable limiter (e.g., 100 requests per 15 minutes per IP), and (3) apply that limiter specifically to the `app.get('*', …)` route that calls `res.sendFile(...)`. This avoids changing how the route works—clients still get `index.html` for unmatched paths—but enforces a cap on how frequently any one client can hit that filesystem-backed route. The rest of the API endpoints remain unchanged. Concretely, we will add a `const rateLimit = require('express-rate-limit');` import, define a `frontendLimiter` (or similarly named) limiter after the `app` is created, and wrap the wildcard route with that middleware: e.g., `app.get('*', frontendLimiter, (req, res) => { … })`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
